### PR TITLE
refresh portal page on deploy events

### DIFF
--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -53,6 +53,5 @@ machine_batch do
 end
 
 machine "#{name}-portal" do
-  recipe 'chef_classroom::portal'
   converge true
 end

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -60,6 +60,5 @@ machine_batch do
 end
 
 machine "#{name}-portal" do
-  recipe 'chef_classroom::portal'
   converge true
 end

--- a/recipes/deploy_server.rb
+++ b/recipes/deploy_server.rb
@@ -47,3 +47,7 @@ machine "#{name}-chefserver" do
   }
   tag 'chefserver'
 end
+
+machine "#{name}-portal" do
+  converge true
+end


### PR DESCRIPTION
The Chef Server deploy event does not force a portal page refresh.

Also, the recipe does not need to be specified when forcing the portal node to re-converge.
