### PR TITLE
Node2 and Node3 count bug fix

### DIFF
--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -50,6 +50,8 @@ machine_batch do
       }
       tag 'node2'
 	  end
+  end
+  1.upto(node3_count) do |i|
     machine "#{name}-node3#{i}" do
   	  machine_options :bootstrap_options =>{
         :security_group_ids => "training-#{name}-node-sg"


### PR DESCRIPTION
Node2 & Node3 counts are specified separately, but are currently only managed by node2_count.  This patch allows node2 & node3 to be managed by their own specified attributes.
