### PR TITLE
Adds public ip reporting for non-bootstrapped nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ bin/*
 nodes/
 clients/
 cookbooks/
+data_bags/
 local-mode-cache/

--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -57,7 +57,9 @@ end
 chef_data_bag "class_machines"
 
 1.upto(node1_count) do |i|
-  ruby_block "look up machine_image object" do
+  ruby_block "look up node1#{i} machine object" do
+    retries 6
+    retry_delay 10
     block do
       aws_object = Chef::Resource::AwsInstance.get_aws_object(
         "#{name}-node1#{i}",
@@ -68,6 +70,7 @@ chef_data_bag "class_machines"
       new_item = Chef::DataBagItem.from_hash({ 'id' => "#{name}-node1#{i}", 'public_ip' => "#{aws_object.public_ip_address}", 'tags' => 'node1'})
       new_item.data_bag('class_machines')
       new_item.save
+      exit(1) if aws_object.public_ip_address.to_s.empty?
     end
   end
 end

--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -52,6 +52,27 @@ machine_batch do
   end
 end
 
+# track what chef provisioning creates
+# hackity hack, don't talk back
+chef_data_bag "class_machines"
+
+1.upto(node1_count) do |i|
+  ruby_block "look up machine_image object" do
+    block do
+      aws_object = Chef::Resource::AwsInstance.get_aws_object(
+        "#{name}-node1#{i}",
+        run_context: run_context,
+        driver: run_context.chef_provisioning.current_driver,
+        managed_entry_store: Chef::Provisioning.chef_managed_entry_store(run_context.cheffish.current_chef_server)
+      )
+      new_item = Chef::DataBagItem.from_hash({ 'id' => "#{name}-node1#{i}", 'public_ip' => "#{aws_object.public_ip_address}", 'tags' => 'node1'})
+      new_item.data_bag('class_machines')
+      new_item.save
+    end
+  end
+end
+#
+
 machine "#{name}-portal" do
   converge true
 end

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -61,6 +61,42 @@ machine_batch do
   end
 end
 
+# track what chef provisioning creates
+# hackity hack, don't talk back
+chef_data_bag "class_machines"
+
+1.upto(node2_count) do |i|
+  ruby_block "look up machine_image object" do
+    block do
+      aws_object = Chef::Resource::AwsInstance.get_aws_object(
+        "#{name}-node2#{i}",
+        run_context: run_context,
+        driver: run_context.chef_provisioning.current_driver,
+        managed_entry_store: Chef::Provisioning.chef_managed_entry_store(run_context.cheffish.current_chef_server)
+      )
+      new_item = Chef::DataBagItem.from_hash({ 'id' => "#{name}-node2#{i}", 'public_ip' => "#{aws_object.public_ip_address}", 'tags' => 'node2'})
+      new_item.data_bag('class_machines')
+      new_item.save
+    end
+  end
+end
+1.upto(node3_count) do |i|
+  ruby_block "look up machine_image object" do
+    block do
+      aws_object = Chef::Resource::AwsInstance.get_aws_object(
+        "#{name}-node3#{i}",
+        run_context: run_context,
+        driver: run_context.chef_provisioning.current_driver,
+        managed_entry_store: Chef::Provisioning.chef_managed_entry_store(run_context.cheffish.current_chef_server)
+      )
+      new_item = Chef::DataBagItem.from_hash({ 'id' => "#{name}-node3#{i}", 'public_ip' => "#{aws_object.public_ip_address}", 'tags' => 'node3'})
+      new_item.data_bag('class_machines')
+      new_item.save
+    end
+  end
+end
+#
+
 machine "#{name}-portal" do
   converge true
 end

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -66,7 +66,9 @@ end
 chef_data_bag "class_machines"
 
 1.upto(node2_count) do |i|
-  ruby_block "look up machine_image object" do
+  ruby_block "look up machine node2#{i} object" do
+    retries 6
+    retry_delay 10
     block do
       aws_object = Chef::Resource::AwsInstance.get_aws_object(
         "#{name}-node2#{i}",
@@ -77,11 +79,14 @@ chef_data_bag "class_machines"
       new_item = Chef::DataBagItem.from_hash({ 'id' => "#{name}-node2#{i}", 'public_ip' => "#{aws_object.public_ip_address}", 'tags' => 'node2'})
       new_item.data_bag('class_machines')
       new_item.save
+      exit(1) if aws_object.public_ip_address.to_s.empty?
     end
   end
 end
 1.upto(node3_count) do |i|
-  ruby_block "look up machine_image object" do
+  ruby_block "look up machine node2#{i} object" do
+    retries 6
+    retry_delay 10
     block do
       aws_object = Chef::Resource::AwsInstance.get_aws_object(
         "#{name}-node3#{i}",
@@ -92,6 +97,7 @@ end
       new_item = Chef::DataBagItem.from_hash({ 'id' => "#{name}-node3#{i}", 'public_ip' => "#{aws_object.public_ip_address}", 'tags' => 'node3'})
       new_item.data_bag('class_machines')
       new_item.save
+      exit(1) if aws_object.public_ip_address.to_s.empty?
     end
   end
 end

--- a/recipes/deploy_workstations.rb
+++ b/recipes/deploy_workstations.rb
@@ -35,6 +35,9 @@ with_chef_server  Chef::Config[:chef_server_url],
   :client_name => Chef::Config[:node_name],
   :signing_key_filename => Chef::Config[:client_key]
 
+# we will need this data_bag later
+chef_data_bag "class_machines"
+
 aws_security_group "training-#{name}-workstation-sg" do
 	action :create
     inbound_rules '0.0.0.0/0' => [ 22, 80 ]

--- a/recipes/destroy_nodes.rb
+++ b/recipes/destroy_nodes.rb
@@ -44,6 +44,10 @@ machine_batch do
   machines 1.upto(node3_count).map { |i| "#{name}-node3#{i}" }
 end
 
+chef_data_bag "class_machines" do
+  action :delete
+end
+
 aws_security_group "training-#{name}-node-sg" do
   action :destroy
 end

--- a/recipes/portal.rb
+++ b/recipes/portal.rb
@@ -38,9 +38,9 @@ template '/var/www/html/index.html' do
 	mode '0644'
 	variables({
     :workstations => search("node","tags:workstation"),
-	  :node1s => search("node","tags:node1"),
-	  :node2s => search("node","tags:node2"),
-	  :node3s => search("node","tags:node3"),
+	  :node1s => search("class_machines","tags:node1"),
+	  :node2s => search("class_machines","tags:node2"),
+	  :node3s => search("class_machines","tags:node3"),
 	  :chefserver => search("node","tags:chefserver")
   })
 end

--- a/templates/default/index.html.erb
+++ b/templates/default/index.html.erb
@@ -31,7 +31,7 @@
       <% @node1s.each do |node1| -%>
       <tr>
         <td><%= "Node1-#{@n1_count += 1}" %></td>
-        <td><%= node1['chef_provisioning']['reference']['image_id'] %></td>
+        <td><%= node1['public_ip'] %></td>
       <%end -%>
       </tr>
     </table>
@@ -49,7 +49,7 @@
       <% @node2s.each do |node2| -%>
       <tr>
         <td><%= "Node2-#{@n2_count += 1}" %></td>
-        <td><%= node2['chef_provisioning']['reference']['image_id'] %></td>
+        <td><%= node2['public_ip'] %></td>
       <%end -%>
       </tr>
     </table>
@@ -67,11 +67,13 @@
       <% @node3s.each do |node3| -%>
       <tr>
         <td><%= "Node3-#{@n3_count += 1}" %></td>
-        <td><%= node3['chef_provisioning']['reference']['image_id'] %></td>
+        <td><%= node3['public_ip'] %></td>
       <%end -%>
       </tr>
     </table>
 <% end -%>
+
+<p>
 
 <% unless @chefserver == Array.new -%>
     <table border="1" style="width:50%">


### PR DESCRIPTION
First attempt at resolving #3.

This method creates a new data_bag meant to track any unmanaged (non-bootstrapped) machines created via the `machine` resource.  That's similar to how chef-provisioning tracks other non-machine resources.  In order to get the public_ip of each aws_object, we have to independently look up each machine with a `ruby_block` after it has been created.  These lookups are serial and time consuming.  Clearly this is suboptimal.

The cleanest approach would seem to be to have the portal machine do lookups just-in-time when needed to render the portal page.  But the portal machine cannot initiate the lookup because it does not have chef-provisioning installed, so none of the necessary tools are available.  If #15 is resolved, there are more reasonable ways of doing this.

Since this 'fix' relies on a new `class_machines` data_bag, that bag must exist before we try searching against it later in the portal recipe.  It is now created as an initial action of setting up the classroom.  An alternative would be to create the data_bag in the portal recipe.  But the `chef_data_bag` resource is not available outside of chef-provisioning and I got lazy.

Implementing this fix for MVP functionality.

Also, it's possible this method may be prone to misreporting IPs if the machine is in a running state but hasn't reported back it's IP.  If we see that, we may need to add it a little bit of retry logic.

Or write a better method.
