### PR TITLE
Windows node support

### DIFF
--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -37,7 +37,7 @@ with_chef_server  Chef::Config[:chef_server_url],
 
 aws_security_group "training-#{name}-node-sg" do
 	action :create
-    inbound_rules '0.0.0.0/0' => [ 22, 80 ]
+    inbound_rules '0.0.0.0/0' => [ 22, 80, 3389, 5985, 5986 ]
 end
 
 machine_batch do

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -54,6 +54,7 @@ machine_batch do
   1.upto(node3_count) do |i|
     machine "#{name}-node3#{i}" do
   	  machine_options :bootstrap_options =>{
+        :image_id => "ami-f70cdd9c",
         :security_group_ids => "training-#{name}-node-sg"
       }
       tag 'node3'

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -38,7 +38,7 @@ with_chef_server  Chef::Config[:chef_server_url],
 
 aws_security_group "training-#{name}-node-sg" do
 	action :create
-    inbound_rules '0.0.0.0/0' => [ 22, 80 ]
+    inbound_rules '0.0.0.0/0' => [ 22, 80, 3389, 5985, 5986 ]
 end
 
 machine_batch do
@@ -56,7 +56,7 @@ machine_batch do
   	  machine_options :bootstrap_options =>{
         :image_id => "ami-f70cdd9c",
         :security_group_ids => "training-#{name}-node-sg"
-      }
+      }, :is_windows => true
       tag 'node3'
 	  end
   end


### PR DESCRIPTION
This PR allows a Windows node to be set up (base OS image) with winrm enabled.
