### PR TITLE
Fixed security group ambiguity

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -41,7 +41,7 @@ module ChefHelpers # Helper Module for general purposes
     node['chef_classroom']['workstation_type']
   end
 
-  def source
+  def class_source_addr
     node['chef_classroom']['ip_range']
   end
 

--- a/recipes/_setup_security_groups.rb
+++ b/recipes/_setup_security_groups.rb
@@ -29,30 +29,30 @@
 require 'chef/provisioning/aws_driver'
 name = node['chef_classroom']['class_name']
 
-portal = aws_security_group "training-#{name}-portal" do
+aws_security_group "training-#{name}-portal" do
 	action :create
-  inbound_rules source => [ 22, 80, 8080 ]
+  inbound_rules class_source_addr => [ 22, 80, 8080 ]
 end
 
 aws_security_group "training-#{name}-workstations" do
 	action :create
-  inbound_rules source 										=> [ 22 ],
+  inbound_rules class_source_addr					=> [ 22 ],
 								"training-#{name}-portal" => [ 22 ]		if type == 'linux'
-  inbound_rules source 										=> [ 3389 ],
+  inbound_rules class_source_addr					=> [ 3389 ],
 								"training-#{name}-portal" => [ 3389 ] if type == 'windows'
 end
 
 aws_security_group "training-#{name}-nodes" do
 	action :create
 	inbound_rules "training-#{name}-workstations" => [ 22, 5985, 5986 ],
-		   					"training-#{name}-portal"		 		=> [ 22, 5985, 5986 ],
-								source			 										=> [ 22, 5985, 5986 ]
+		   					"training-#{name}-portal"		 		=> [ 22, 5985, 5986 ], # for bootstrapping from portal
+								class_source_addr								=> [ 22, 5985, 5986 ] # until portal does bootstrapping
 end
 
 aws_security_group "training-#{name}-chef_server" do
 	action :create
-  inbound_rules source			 							=> [ 80, 443 ],
+  inbound_rules class_source_addr					=> [ 80, 443 ],
 								"training-#{name}-nodes"	=> [ 443 ],
-								source										=> [ 22 ], # until portal does bootstrapping
-								"training-#{name}-portal" => [ 22 ]
+								"training-#{name}-portal" => [ 22 ], # for bootstrapping from portal
+								class_source_addr					=> [ 22 ] # until portal does bootstrapping
 end


### PR DESCRIPTION
Security group setup uses the term `source` which is confusing and adds ambiguity since the `template` resource also has a `source` parameter.
