### PR TITLE
Regional AWS localizations added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/*
 # Chef Zero
 nodes/
 clients/
+keys/
 cookbooks/
 data_bags/
 local-mode-cache/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ In order to use this repo, you must have the following setup:
 
 ## Usage
 
+Note: this repo uses AWS Marketplace AMIs for Centos6, Windows 2012, and Chef Server.  **You must accept the licensing terms** from your AWS account for each of those AMIs, in each region for which you want to deploy a classroom, before this repo will work.  If you have not, chef-provisioning-aws will throw an error letting you know you must go do this.
+
 To set up a Chef Training Classroom, do the following:
 
 1. Create your `~/.aws/config` file if you don't already have one.  It should have content similar to the snippet below, except with your own AWS API credentials here:
@@ -20,22 +22,25 @@ To set up a Chef Training Classroom, do the following:
     aws_secret_access_key = "Abc0123dEf4GhIjk5lMn/OpQrSTUvXyz/A678bCD"
     ```
 
-2. Set your AWS localization options in the `knife.rb` file.  Specifically, you must enter a valid `key_name` in the `:bootstrap_options` section.  You should not need to change any other fields unless you wish to try this in another AWS region.
+2. At a minimum, ensure the correct value for `chef_classroom['ssh_key_name']` is set in `attributes/default.rb`.
 
-3. Ensure the private key associated with the ssh key you just specified is located in your `~/.ssh` directory.  For example, if using the default value in this repo's `knife.rb` you would need the correspoding private key in `~/.ssh/aws-id_rsa`.
+3. Ensure the private key associated with the ssh key you just specified is located in your `~/.ssh` directory.  For example, if using the default value in this repo's attributes file `"aws-id_rsa"` you would need the corresponding private key in `~/.ssh/aws-id_rsa`.
 
-4. Run `berks vendor cookbooks`
+4. Additional options may be set, including automatic localization via the `chef_classroom['region']` attribute (note: so far only AWS US regions available).  Ensure that your `ssh_key_name` is valid for any region you set.  It is recommended that instructors replace the value of `chef_classroom['ip_range']` with an appropriate IP address range (e.g. "184.106.28.82/24") for any classroom being managed.  The permissions and security settings of these instances are... lax.  However, none of these changes are required for basic (demo) use of this repo.
 
-5. Run `chef-client -z -r 'recipe[chef_classroom]'` (or see the demo steps below)
+5. Run `berks vendor cookbooks`
 
-You should now have a classroom set up.  *Note: at present the Chef Server setup takes ~15 mins and consumes a large majority of the classroom setup time (~20 mins).*  To find the portal node, at this time the best way is to run the command `grep public_ipv4 nodes/mytraining-portal.json`.  There's a gem conflict preventing knife from working in local-mode that should be resolved the next time ChefDK ships.
+6. Run `chef-client -z -r 'recipe[chef_classroom]'` (or see the demo steps below)
+
+You should now have a classroom set up.  To find the portal node, at this time the best way is to run the command `grep public_ipv4 nodes/mytraining-portal.json`.  There's a gem conflict preventing knife from working in local-mode that should be resolved the next time ChefDK ships.
 
 Visit the portal node in a web browser.  Additional actions [should be taken](https://github.com/gmiranda23/chef_classroom/issues/14) from the portal.
 
+***Note: at present the Chef Server setup takes ~15 mins and consumes a large majority of the classroom setup time (~30 mins).  The initial compile of guacamole on the portal instance is also significant (~10 mins).  The goal is to stop building these on the fly and use pre-baked images instead (using the chef recipes demonstrated here) once this passes the MVP phase.***
 
 ## Classroom workflow demonstration
 
-The default recipe just creates an entire classroom environment in one fell swoop.  The way ChefDK fundamentals is taught, that leaves a bunch of idle infrastructure laying around before it is ever needed.  That also doesn't match the desired instructor experience.
+The default recipe just creates an entire classroom environment in one fell swoop.  The way ChefDK fundamentals is taught, that leaves a bunch of idle infrastructure consuming cost before we ever use it.  The desired instructor experience is to make this infrastructure available just-in-time.
 
 To achieve the desired instructor experience, follow these steps to see a demo classroom workflow.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,17 +1,20 @@
-# refactored so student number handles environment size. all students get:
-# 1 pre-configured workstation
-# 1 initial node to manage
-# 2 additional nodes when multi-node is taught
+# for each class, all students get:
+# 1 pre-configured workstation (amzn)
+# 1 initial node to manage (centos)
+# 2 additional nodes when multi-node is taught (1 centos, 1 windows)
 default['chef_classroom']['class_name'] = 'mytraining'
 default['chef_classroom']['number_of_students'] = 2
 default['chef_classroom']['ip_range'] = '0.0.0.0/0'
 
-# only current working option is linux (roadmap: add windows)
+# regional aws settings
+default['chef_classroom']['region'] = 'us-east-1'
+default['chef_classroom']['ssh_key_name'] = 'aws-id_rsa'
+
+# tweak workstation_type (only current option is linux -- roadmap: add windows)
 default['chef_classroom']['workstation_type'] = 'linux'
 
 # tweak instance sizes
 default['chef_classroom']['workstation_size'] = 't2.medium'
 default['chef_classroom']['node_size'] = 't2.micro'
-
 default['chef_classroom']['portal_size'] = 'm3.medium'
 default['chef_classroom']['chef_server_size'] = 'm3.medium'

--- a/knife.rb
+++ b/knife.rb
@@ -1,25 +1,5 @@
 log_level                :info
 log_location             STDOUT
-node_name                "mynode"
+node_name                "local_workstation"
 cache_type               'BasicFile'
 cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
-#
-profiles({
-  'default' => {
-    :driver => 'aws',
-    :machine_options => {
-      :region => 'us-east-1',
-      :ssh_username => 'ec2-user',
-      :convergence_options => {
-        :ssl_verify_mode => :verify_none,
-        :chef_version => "12.2.1"
-      },
-      :bootstrap_options => {
-        :instance_type => 'm3.medium',
-        :image_id => 'ami-1ecae776',
-        :key_name => 'aws-id_rsa'
-      }
-    }
-  }
- }
-)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,54 +53,169 @@ module ChefHelpers # Helper Module for general purposes
     node['chef_classroom']['portal_size']
   end
 
+  def region
+    node['chef_classroom']['region']
+  end
+
+  def ssh_key
+    node['chef_classroom']['ssh_key_name']
+  end
+
   def server_size
-    node['chef_classroom']['server_size']
+    node['chef_classroom']['chef_server_size']
   end
 
   def workstation_size
     node['chef_classroom']['workstation_size']
   end
 
-  # def lookup_region_ami(type)
-  #   case node['chef_classroom']['region']
-  #   when 'us-east-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'us-west-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'us-west-2'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'eu-west-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'eu-central-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'ap-southeast-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'ap-southeast-2'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'ap-northeast-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   when 'sa-east-1'
-  #     'ami-a1b2c3d4' if type == 'amzn'
-  #     'ami-b2c3d4e5' if type == 'centos'
-  #     'ami-c3d4e5f6' if type == 'windows'
-  #   end
-  # end
+  def lookup_region_ami(region, type)
+    case region
+
+    when 'us-east-1'
+      case type
+      when 'amzn'
+        'ami-1ecae776'
+      when 'centos'
+        'ami-c2a818aa'
+      when 'windows'
+        'ami-f70cdd9c'
+      when 'marketplace'
+        'ami-0d2ce366'
+      end
+
+    when 'us-west-1'
+      case type
+      when 'amzn'
+        'ami-d114f295'
+      when 'centos'
+        'ami-57cfc412'
+      when 'windows'
+        'ami-c751a283'
+      when 'marketplace'
+        'ami-3509f971'
+      end
+
+    when 'us-west-2'
+      case type
+      when 'amzn'
+        'ami-e7527ed7'
+      when 'centos'
+        'ami-81d092b1'
+      when 'windows'
+        'ami-5b57556b'
+      when 'marketplace'
+        'ami-0b42423b'
+      end
+
+    # when 'eu-west-1'
+    #   case type
+    #   when 'amzn'
+    #     'ami-a1b2c3d4'
+    #   when 'centos'
+    #     'ami-b2c3d4e5'
+    #   when 'windows'
+    #     'ami-c3d4e5f6'
+    #   when 'marketplace'
+    #     'ami-d4e5f6g7'
+    #   end
+    #
+    # when 'eu-central-1'
+    #   case type
+    #   when 'amzn'
+    #     'ami-a1b2c3d4'
+    #   when 'centos'
+    #     'ami-b2c3d4e5'
+    #   when 'windows'
+    #     'ami-c3d4e5f6'
+    #   when 'marketplace'
+    #     'ami-d4e5f6g7'
+    #   end
+    #
+    # when 'ap-southeast-1'
+    #   case type
+    #   when 'amzn'
+    #     'ami-a1b2c3d4'
+    #   when 'centos'
+    #     'ami-b2c3d4e5'
+    #   when 'windows'
+    #     'ami-c3d4e5f6'
+    #   when 'marketplace'
+    #     'ami-d4e5f6g7'
+    #   end
+    #
+    # when 'ap-southeast-2'
+    #   case type
+    #   when 'amzn'
+    #     'ami-a1b2c3d4'
+    #   when 'centos'
+    #     'ami-b2c3d4e5'
+    #   when 'windows'
+    #     'ami-c3d4e5f6'
+    #   when 'marketplace'
+    #     'ami-d4e5f6g7'
+    #   end
+    #
+    # when 'ap-northeast-1'
+    #   case type
+    #   when 'amzn'
+    #     'ami-a1b2c3d4'
+    #   when 'centos'
+    #     'ami-b2c3d4e5'
+    #   when 'windows'
+    #     'ami-c3d4e5f6'
+    #   when 'marketplace'
+    #     'ami-d4e5f6g7'
+    #   end
+    #
+    # when 'sa-east-1'
+    #   case type
+    #   when 'amzn'
+    #     'ami-a1b2c3d4'
+    #   when 'centos'
+    #     'ami-b2c3d4e5'
+    #   when 'windows'
+    #     'ami-c3d4e5f6'
+    #   when 'marketplace'
+    #     'ami-d4e5f6g7'
+    #   end
+
+    end
+  end
+
+  def lookup_ami_user(type)
+    case type
+    when 'amzn'
+      'ec2-user'
+    when 'centos'
+      'root'
+    when 'windows'
+      'Administrator'
+    when 'marketplace'
+      'ec2-user'
+    end
+  end
+
+  def create_machine_options(region, type, size, ssh_key, group)
+    options = {
+      :region => region,
+      :ssh_username => lookup_ami_user(type),
+      :convergence_options => {
+        :ssl_verify_mode => :verify_none,
+        :chef_version => "12.2.1"
+      },
+      :bootstrap_options => {
+        :instance_type => size,
+        :image_id => lookup_region_ami(region, type),
+        :key_name => ssh_key,
+        :security_group_ids => "training-#{node['chef_classroom']['class_name']}-#{group}"
+      }
+    }
+    if type == 'windows'
+      options[:is_windows] = true
+    end
+    options
+  end
 
 end
 

--- a/recipes/_destroy_security_groups.rb
+++ b/recipes/_destroy_security_groups.rb
@@ -27,6 +27,8 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
+
 name = node['chef_classroom']['class_name']
 
 %w(chef_server nodes workstations portal).each do |secgroup|

--- a/recipes/_setup_security_groups.rb
+++ b/recipes/_setup_security_groups.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 aws_security_group "training-#{name}-portal" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,3 +32,9 @@ include_recipe 'chef_classroom::deploy_workstations'
 include_recipe 'chef_classroom::deploy_first_nodes'
 include_recipe 'chef_classroom::deploy_server'
 include_recipe 'chef_classroom::deploy_multi_nodes'
+
+name = node['chef_classroom']['class_name']
+machine "#{name}-portal" do
+  machine_options :ssh_username => 'root'
+  converge true
+end

--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -27,16 +27,14 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine_batch do
   action :allocate
   1.upto(count) do |i|
     machine "#{name}-node1-#{i}" do
-  	  machine_options :bootstrap_options => {
-                        :instance_type => node_size,
-                        :security_group_ids => "training-#{name}-nodes"
-                      }
+      machine_options create_machine_options(region, 'amzn', node_size, ssh_key, 'nodes')
       tag 'node1'
 	  end
   end

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -27,26 +27,20 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine_batch do
   action :allocate
   1.upto(count) do |i|
     machine "#{name}-node2-#{i}" do
-  	  machine_options :bootstrap_options => {
-                        :instance_type => node_size,
-                        :security_group_ids => "training-#{name}-nodes"
-                      }
+  	  machine_options create_machine_options(region, 'amzn', node_size, ssh_key, 'nodes')
       tag 'node2'
 	  end
   end
   1.upto(count) do |i|
     machine "#{name}-node3-#{i}" do
-  	  machine_options :bootstrap_options =>{
-                        :image_id => "ami-f70cdd9c",
-                        :instance_type => node_size,
-                        :security_group_ids => "training-#{name}-nodes"
-                      }, :is_windows => true
+      machine_options create_machine_options(region, 'windows', node_size, ssh_key, 'nodes')
       tag 'node3'
 	  end
   end

--- a/recipes/deploy_portal.rb
+++ b/recipes/deploy_portal.rb
@@ -27,16 +27,14 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
-# we will need this data_bag later
+# the portal will need this data_bag later
 chef_data_bag "class_machines"
 
 machine "#{name}-portal" do
-  machine_options :bootstrap_options => {
-                    :image_id => "ami-c2a818aa",
-                    :security_group_ids => "training-#{name}-portal"
-                  }, :ssh_username => 'root'
+  machine_options create_machine_options(region, 'centos', portal_size, ssh_key, 'portal')
   recipe 'chef_classroom::portal'
   converge true
 end

--- a/recipes/deploy_server.rb
+++ b/recipes/deploy_server.rb
@@ -27,14 +27,11 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine "#{name}-chefserver" do
-  machine_options :bootstrap_options => {
-                    :security_group_ids => "training-#{name}-chef_server",
-                    :instance_type => server_size,
-                    :image_id => 'ami-0d2ce366'
-                  }
+  machine_options create_machine_options(region, 'marketplace', server_size, ssh_key, 'chef_server')
   tag 'chefserver'
   recipe 'chef_classroom::server'
 end

--- a/recipes/deploy_workstations.rb
+++ b/recipes/deploy_workstations.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 # we will need this data_bag later
@@ -35,10 +36,7 @@ chef_data_bag "class_machines"
 machine_batch do
   1.upto(count) do |i|
     machine "#{name}-workstation-#{i}" do
-  	  machine_options :bootstrap_options => {
-                        :instance_type => workstation_size,
-                        :security_group_ids => "training-#{name}-workstations"
-                      }
+      machine_options create_machine_options(region, 'amzn', workstation_size, ssh_key, 'nodes')
       tag 'workstation'
   	  recipe 'chef_workstation::full_stack'
       attribute 'guacamole_user', 'chef'

--- a/recipes/destroy_nodes.rb
+++ b/recipes/destroy_nodes.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine_batch do

--- a/recipes/destroy_portal.rb
+++ b/recipes/destroy_portal.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine "#{name}-portal" do

--- a/recipes/destroy_server.rb
+++ b/recipes/destroy_server.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine "#{name}-chefserver" do

--- a/recipes/destroy_workstations.rb
+++ b/recipes/destroy_workstations.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'chef/provisioning/aws_driver'
+with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 machine_batch do


### PR DESCRIPTION
Resolves issues #10 and #11.

Verified to work across us-east-1, us-west-1, and us-west-2.  Scaffolding in place to work for additional regions with AMI mappings added into helper methods.

Updated README instructions.  Added `with_driver` to support regional updates.  Added in helper methods to generate per machine options for every machine.
