### PR TITLE
Allow portal provisioning first

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -239,7 +239,7 @@ module ChefHelpers # Helper Module for general purposes
         'password' => 'chef',
         'machines' => {}
       }
-      usermap[i]['machines']['workstation'] = workstation unless workstation.empty?
+      usermap[i]['machines']['workstation'] = workstation unless workstation.nil?
       usermap[i]['machines']['node1'] = node1 unless node1.nil?
       usermap[i]['machines']['node2'] = node2 unless node2.nil?
       usermap[i]['machines']['node3'] = node3 unless node3.nil?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,8 +27,8 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 include_recipe 'chef_classroom::_setup_security_groups'
-include_recipe 'chef_classroom::deploy_workstations'
 include_recipe 'chef_classroom::deploy_portal'
+include_recipe 'chef_classroom::deploy_workstations'
 include_recipe 'chef_classroom::deploy_first_nodes'
 include_recipe 'chef_classroom::deploy_server'
 include_recipe 'chef_classroom::deploy_multi_nodes'

--- a/templates/default/index.html.erb
+++ b/templates/default/index.html.erb
@@ -135,7 +135,9 @@
           <% @chefserver.each do |server| -%>
           <tr>
             <td><%= "Chef Server" %></td>
-            <td><%= server['ec2']['public_ipv4'] %></td>
+            <td><a href="https://<%= server['ec2']['public_ipv4'] -%>">
+              <%= server['ec2']['public_ipv4'] %></a>
+            </td>
           <%end -%>
           </tr>
         </table>


### PR DESCRIPTION
The helper lib populating the guacamole usermap was busted, but that wasn't exposed until I tried to provision a portal as the first step in the workflow.  Fixed it so that now the portal comes up first.

This does not entirely address #15, but this is a necessary first step.
