### PR TITLE
Make portal node the primary provisioning actor

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 cookbook 'chef_workstation', git: 'git://github.com/gmiranda23/chef_workstation.git'
 # cookbook 'guacamole', git: 'git://github.com/mattstratton/guacamole-cookbook.git'
 cookbook 'guacamole', git: 'git://github.com/gmiranda23/guacamole-cookbook.git'
+# cookbook 'chef_portal', path: '../chef_portal'
 cookbook 'chef_portal', git: 'git://github.com/gmiranda23/chef_portal.git'

--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,4 @@ metadata
 cookbook 'chef_workstation', git: 'git://github.com/gmiranda23/chef_workstation.git'
 # cookbook 'guacamole', git: 'git://github.com/mattstratton/guacamole-cookbook.git'
 cookbook 'guacamole', git: 'git://github.com/gmiranda23/guacamole-cookbook.git'
+cookbook 'chef_portal', git: 'git://github.com/gmiranda23/chef_portal.git'

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,4 @@ metadata
 cookbook 'chef_workstation', git: 'git://github.com/gmiranda23/chef_workstation.git'
 # cookbook 'guacamole', git: 'git://github.com/mattstratton/guacamole-cookbook.git'
 cookbook 'guacamole', git: 'git://github.com/gmiranda23/guacamole-cookbook.git'
-# cookbook 'chef_portal', path: '../chef_portal'
 cookbook 'chef_portal', git: 'git://github.com/gmiranda23/chef_portal.git'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,9 +10,6 @@ default['chef_classroom']['ip_range'] = '0.0.0.0/0'
 default['chef_classroom']['region'] = 'us-east-1'
 default['chef_classroom']['iam_instance_profile'] = 'arn:aws:iam::458523137226:instance-profile/provisioner'
 
-# this should be deprecated soon
-default['chef_classroom']['ssh_key_name'] = 'aws-popup-chef'
-
 # tweak workstation_type (only current option is linux -- roadmap: add windows)
 default['chef_classroom']['workstation_type'] = 'linux'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,7 +8,10 @@ default['chef_classroom']['ip_range'] = '0.0.0.0/0'
 
 # regional aws settings
 default['chef_classroom']['region'] = 'us-east-1'
-default['chef_classroom']['ssh_key_name'] = 'aws-id_rsa'
+default['chef_classroom']['iam_instance_profile'] = 'arn:aws:iam::458523137226:instance-profile/provisioner'
+
+# this should be deprecated soon
+default['chef_classroom']['ssh_key_name'] = 'aws-popup-chef'
 
 # tweak workstation_type (only current option is linux -- roadmap: add windows)
 default['chef_classroom']['workstation_type'] = 'linux'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -221,6 +221,9 @@ module ChefHelpers # Helper Module for general purposes
     if group == 'portal'
       options[:bootstrap_options][:iam_instance_profile] = node['chef_classroom']['iam_instance_profile']
     end
+    unless group == 'portal'
+      options[:use_private_ip_for_ssh] = true
+    end
     options
   end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -218,7 +218,7 @@ module ChefHelpers # Helper Module for general purposes
     if type == 'windows'
       options[:is_windows] = true
     end
-    if type == 'portal'
+    if group == 'portal'
       options[:bootstrap_options][:iam_instance_profile] = node['chef_classroom']['iam_instance_profile']
     end
     options

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -214,6 +214,9 @@ module ChefHelpers # Helper Module for general purposes
     if type == 'windows'
       options[:is_windows] = true
     end
+
+    options[:bootstrap_options][:iam_instance_profile] = 'arn:aws:iam::458523137226:instance-profile/provisioner'
+
     options
   end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -57,8 +57,12 @@ module ChefHelpers # Helper Module for general purposes
     node['chef_classroom']['region']
   end
 
-  def ssh_key
-    node['chef_classroom']['ssh_key_name']
+  def portal_key
+    node['chef_classroom']['class_name'] + "-portal_key"
+  end
+
+  def workstation_key
+    node['chef_classroom']['class_name'] + "-workstation_key"
   end
 
   def server_size
@@ -214,9 +218,9 @@ module ChefHelpers # Helper Module for general purposes
     if type == 'windows'
       options[:is_windows] = true
     end
-
-    options[:bootstrap_options][:iam_instance_profile] = 'arn:aws:iam::458523137226:instance-profile/provisioner'
-
+    if type == 'portal'
+      options[:bootstrap_options][:iam_instance_profile] = node['chef_classroom']['iam_instance_profile']
+    end
     options
   end
 
@@ -249,7 +253,12 @@ module ChefHelpers # Helper Module for general purposes
     end
     usermap
   end
+
+  def iam_role_name
+    node['chef_classroom']['iam_instance_profile'].split('/')[1]
+  end
 end
+
 
 Chef::Recipe.send(:include, ChefHelpers)
 Chef::Resource.send(:include, ChefHelpers)

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,4 @@ version '0.2.0'
 
 depends 'chef_workstation'
 depends 'guacamole'
+depends 'chef_portal'

--- a/recipes/_destroy_portal_key.rb
+++ b/recipes/_destroy_portal_key.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: chef_classroom
-# Recipe:: _destroy_security_groups
+# Recipe:: _portal_ssh_key
 #
 # Author:: Ned Harris (<nharris@chef.io>)
 # Author:: George Miranda (<gmiranda@chef.io>)
@@ -28,11 +28,13 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-
 name = node['chef_classroom']['class_name']
 
-%w(chef_server nodes workstations).each do |secgroup|
-  aws_security_group "training-#{name}-#{secgroup}" do
-    action :destroy
-  end
+aws_key_pair "#{name}-portal_key" do
+  action :destroy
+end
+
+file "#{ENV['HOME']}/.ssh/#{name}-portal_key" do
+  action :delete
+  backup false
 end

--- a/recipes/_destroy_portal_key.rb
+++ b/recipes/_destroy_portal_key.rb
@@ -28,13 +28,13 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-name = node['chef_classroom']['class_name']
 
-aws_key_pair "#{name}-portal_key" do
+
+aws_key_pair portal_key do
   action :destroy
 end
 
-file "#{ENV['HOME']}/.ssh/#{name}-portal_key" do
+file "#{ENV['HOME']}/.ssh/#{portal_key}" do
   action :delete
   backup false
 end

--- a/recipes/_destroy_workstation_key.rb
+++ b/recipes/_destroy_workstation_key.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: chef_classroom
-# Recipe:: _destroy_security_groups
+# Recipe:: _portal_ssh_key
 #
 # Author:: Ned Harris (<nharris@chef.io>)
 # Author:: George Miranda (<gmiranda@chef.io>)
@@ -28,11 +28,13 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-
 name = node['chef_classroom']['class_name']
 
-%w(chef_server nodes workstations).each do |secgroup|
-  aws_security_group "training-#{name}-#{secgroup}" do
-    action :destroy
-  end
+aws_key_pair "#{name}-workstation_key" do
+  action :destroy
+end
+
+file "#{ENV['HOME']}/.ssh/#{name}-workstation_key" do
+  action :delete
+  backup false
 end

--- a/recipes/_destroy_workstation_key.rb
+++ b/recipes/_destroy_workstation_key.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: chef_classroom
-# Recipe:: _portal_ssh_key
+# Recipe:: _destroy_workstation_key
 #
 # Author:: Ned Harris (<nharris@chef.io>)
 # Author:: George Miranda (<gmiranda@chef.io>)
@@ -30,11 +30,11 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
-aws_key_pair "#{name}-workstation_key" do
+aws_key_pair workstation_key do
   action :destroy
 end
 
-file "#{ENV['HOME']}/.ssh/#{name}-workstation_key" do
+file "#{ENV['HOME']}/.ssh/#{workstation_key}" do
   action :delete
   backup false
 end

--- a/recipes/_refresh_portal.rb
+++ b/recipes/_refresh_portal.rb
@@ -26,10 +26,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-require 'chef/provisioning/aws_driver'
-name = node['chef_classroom']['class_name']
+# require 'chef/provisioning/aws_driver'
+# name = node['chef_classroom']['class_name']
+#
+# machine "#{name}-portal" do
+#   machine_options :ssh_username => 'root'
+#   converge true
+# end
 
-machine "#{name}-portal" do
-  machine_options :ssh_username => 'root'
-  converge true
-end
+include_recipe 'chef_portal::fundamentals_3x_webapp'

--- a/recipes/_setup_portal_key.rb
+++ b/recipes/_setup_portal_key.rb
@@ -28,9 +28,8 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-name = node['chef_classroom']['class_name']
 
-aws_key_pair "#{name}-portal_key" do
+aws_key_pair portal_key do
   allow_overwrite false
-	private_key_path "#{ENV['HOME']}/.ssh/#{name}-portal_key"
+	private_key_path "#{ENV['HOME']}/.ssh/#{portal_key}"
 end

--- a/recipes/_setup_portal_key.rb
+++ b/recipes/_setup_portal_key.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: chef_classroom
-# Recipe:: _destroy_security_groups
+# Recipe:: _portal_ssh_key
 #
 # Author:: Ned Harris (<nharris@chef.io>)
 # Author:: George Miranda (<gmiranda@chef.io>)
@@ -28,11 +28,9 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-
 name = node['chef_classroom']['class_name']
 
-%w(chef_server nodes workstations).each do |secgroup|
-  aws_security_group "training-#{name}-#{secgroup}" do
-    action :destroy
-  end
+aws_key_pair "#{name}-portal_key" do
+  allow_overwrite false
+	private_key_path "#{ENV['HOME']}/.ssh/#{name}-portal_key"
 end

--- a/recipes/_setup_security_groups.rb
+++ b/recipes/_setup_security_groups.rb
@@ -30,23 +30,26 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
-aws_security_group "training-#{name}-portal" do
-  action :create
-  inbound_rules class_source_addr => [22, 80, 8080]
-end
+# aws_security_group "training-#{name}-portal" do
+#   action :create
+#   inbound_rules class_source_addr => [22, 80, 8080]
+# end
 
 aws_security_group "training-#{name}-workstations" do
   action :create
   inbound_rules class_source_addr         => [22],
-                "training-#{name}-portal" => [22]   if type == 'linux'
+                node['ec2']['local_ipv4'] => [22]   if type == 'linux'
+                # "training-#{name}-portal" => [22]   if type == 'linux'
   inbound_rules class_source_addr         => [3389],
-                "training-#{name}-portal" => [3389] if type == 'windows'
+                node['ec2']['local_ipv4'] => [22]   if type == 'windows'
+                # "training-#{name}-portal" => [3389] if type == 'windows'
 end
 
 aws_security_group "training-#{name}-nodes" do
   action :create
   inbound_rules "training-#{name}-workstations" => [22, 5985, 5986],
-                "training-#{name}-portal"       => [22, 5985, 5986], # for bootstrapping from portal
+                node['ec2']['local_ipv4']       => [22, 5985, 5986],
+                # "training-#{name}-portal"       => [22, 5985, 5986], # for bootstrapping from portal
                 class_source_addr               => [22, 5985, 5986] # until portal does bootstrapping
 end
 
@@ -54,5 +57,6 @@ aws_security_group "training-#{name}-chef_server" do
   action :create
   inbound_rules class_source_addr         => [22, 80, 443], # 22 only until portal does bootstrapping
                 "training-#{name}-nodes"  => [443],
-                "training-#{name}-portal" => [22] # for bootstrapping from portal
+                node['ec2']['local_ipv4'] => [22],
+                # "training-#{name}-portal" => [22] # for bootstrapping from portal
 end

--- a/recipes/_setup_security_groups.rb
+++ b/recipes/_setup_security_groups.rb
@@ -39,24 +39,20 @@ aws_security_group "training-#{name}-workstations" do
   action :create
   inbound_rules class_source_addr         => [22],
                 node['ec2']['local_ipv4'] => [22]   if type == 'linux'
-                # "training-#{name}-portal" => [22]   if type == 'linux'
   inbound_rules class_source_addr         => [3389],
                 node['ec2']['local_ipv4'] => [22]   if type == 'windows'
-                # "training-#{name}-portal" => [3389] if type == 'windows'
 end
 
 aws_security_group "training-#{name}-nodes" do
   action :create
   inbound_rules "training-#{name}-workstations" => [22, 5985, 5986],
                 node['ec2']['local_ipv4']       => [22, 5985, 5986],
-                # "training-#{name}-portal"       => [22, 5985, 5986], # for bootstrapping from portal
-                class_source_addr               => [22, 5985, 5986] # until portal does bootstrapping
+                class_source_addr               => [22, 5985, 5986]
 end
 
 aws_security_group "training-#{name}-chef_server" do
   action :create
-  inbound_rules class_source_addr         => [22, 80, 443], # 22 only until portal does bootstrapping
+  inbound_rules class_source_addr         => [80, 443],
                 "training-#{name}-nodes"  => [443],
-                node['ec2']['local_ipv4'] => [22],
-                # "training-#{name}-portal" => [22] # for bootstrapping from portal
+                node['ec2']['local_ipv4'] => [22]
 end

--- a/recipes/_setup_workstation_key.rb
+++ b/recipes/_setup_workstation_key.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: chef_classroom
-# Recipe:: _destroy_security_groups
+# Recipe:: _portal_ssh_key
 #
 # Author:: Ned Harris (<nharris@chef.io>)
 # Author:: George Miranda (<gmiranda@chef.io>)
@@ -28,11 +28,9 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-
 name = node['chef_classroom']['class_name']
 
-%w(chef_server nodes workstations).each do |secgroup|
-  aws_security_group "training-#{name}-#{secgroup}" do
-    action :destroy
-  end
+aws_key_pair "#{name}-workstation_key" do
+  allow_overwrite false
+	private_key_path "#{ENV['HOME']}/.ssh/#{name}-workstation_key"
 end

--- a/recipes/_setup_workstation_key.rb
+++ b/recipes/_setup_workstation_key.rb
@@ -28,9 +28,8 @@
 
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
-name = node['chef_classroom']['class_name']
 
-aws_key_pair "#{name}-workstation_key" do
+aws_key_pair workstation_key do
   allow_overwrite false
-	private_key_path "#{ENV['HOME']}/.ssh/#{name}-workstation_key"
+	private_key_path "#{ENV['HOME']}/.ssh/#{workstation_key}"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,8 +26,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+include_recipe 'chef_portal::_refresh_iam_creds'
 include_recipe 'chef_classroom::_setup_security_groups'
-include_recipe 'chef_classroom::deploy_portal'
+#include_recipe 'chef_classroom::deploy_portal'
 include_recipe 'chef_classroom::deploy_workstations'
 include_recipe 'chef_classroom::deploy_first_nodes'
 include_recipe 'chef_classroom::deploy_server'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,9 +33,3 @@ include_recipe 'chef_classroom::deploy_workstations'
 include_recipe 'chef_classroom::deploy_first_nodes'
 include_recipe 'chef_classroom::deploy_server'
 include_recipe 'chef_classroom::deploy_multi_nodes'
-
-name = node['chef_classroom']['class_name']
-machine "#{name}-portal" do
-  machine_options :ssh_username => 'root'
-  converge true
-end

--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 machine_batch do
   action :allocate
   1.upto(count) do |i|

--- a/recipes/deploy_first_nodes.rb
+++ b/recipes/deploy_first_nodes.rb
@@ -36,7 +36,7 @@ machine_batch do
   action :allocate
   1.upto(count) do |i|
     machine "#{name}-node1-#{i}" do
-      machine_options create_machine_options(region, 'amzn', node_size, ssh_key, 'nodes')
+      machine_options create_machine_options(region, 'amzn', node_size, portal_key, 'nodes')
       tag 'node1'
     end
   end

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -36,11 +36,11 @@ machine_batch do
   action :allocate
   1.upto(count) do |i|
     machine "#{name}-node2-#{i}" do
-      machine_options create_machine_options(region, 'amzn', node_size, ssh_key, 'nodes')
+      machine_options create_machine_options(region, 'amzn', node_size, portal_key, 'nodes')
       tag 'node2'
     end
     machine "#{name}-node3-#{i}" do
-      machine_options create_machine_options(region, 'windows', node_size, ssh_key, 'nodes')
+      machine_options create_machine_options(region, 'windows', node_size, portal_key, 'nodes')
       tag 'node3'
     end
   end

--- a/recipes/deploy_multi_nodes.rb
+++ b/recipes/deploy_multi_nodes.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 machine_batch do
   action :allocate
   1.upto(count) do |i|

--- a/recipes/deploy_portal.rb
+++ b/recipes/deploy_portal.rb
@@ -29,12 +29,20 @@
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
+workstation_ssh_key = "#{name}-workstation_key"
 
 # the portal will need this data_bag later
 chef_data_bag 'class_machines'
 
+include_recipe 'chef_classroom::_setup_workstation_key'
+
+aws_security_group "training-#{name}-portal" do
+  action :create
+  inbound_rules class_source_addr => [22, 80, 8080]
+end
+
 machine "#{name}-portal" do
-  machine_options create_machine_options(region, 'centos', portal_size, ssh_key, 'portal')
-  recipe 'chef_classroom::portal'
+  machine_options create_machine_options(region, 'centos', portal_size, workstation_ssh_key, 'portal')
+  recipe 'chef_portal::fundamentals_3x'
   converge true
 end

--- a/recipes/deploy_portal.rb
+++ b/recipes/deploy_portal.rb
@@ -29,7 +29,6 @@
 require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
-workstation_ssh_key = "#{name}-workstation_key"
 
 # the portal will need this data_bag later
 chef_data_bag 'class_machines'
@@ -42,7 +41,7 @@ aws_security_group "training-#{name}-portal" do
 end
 
 machine "#{name}-portal" do
-  machine_options create_machine_options(region, 'centos', portal_size, workstation_ssh_key, 'portal')
+  machine_options create_machine_options(region, 'centos', portal_size, workstation_key, 'portal')
   recipe 'chef_portal::fundamentals_3x'
   converge true
 end

--- a/recipes/deploy_server.rb
+++ b/recipes/deploy_server.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 machine "#{name}-chefserver" do
   machine_options create_machine_options(region, 'marketplace', server_size, ssh_key, 'chef_server')
   tag 'chefserver'

--- a/recipes/deploy_server.rb
+++ b/recipes/deploy_server.rb
@@ -33,7 +33,7 @@ name = node['chef_classroom']['class_name']
 include_recipe 'chef_portal::_refresh_iam_creds'
 
 machine "#{name}-chefserver" do
-  machine_options create_machine_options(region, 'marketplace', server_size, ssh_key, 'chef_server')
+  machine_options create_machine_options(region, 'marketplace', server_size, portal_key, 'chef_server')
   tag 'chefserver'
   recipe 'chef_classroom::server'
 end

--- a/recipes/deploy_workstations.rb
+++ b/recipes/deploy_workstations.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 # we will need this data_bag later
 chef_data_bag 'class_machines'
 

--- a/recipes/deploy_workstations.rb
+++ b/recipes/deploy_workstations.rb
@@ -30,12 +30,14 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
-include_recipe 'chef_portal::_refresh_iam_creds'
-include_recipe 'chef_portal::_setup_security_groups'
-include_recipe 'chef_portal::_setup_portal_key'
+# we need this data_bag sooner rather than later
+chef_data_bag 'class_machines' do
+  action :nothing
+end.run_action(:create)
 
-# we will need this data_bag later
-chef_data_bag 'class_machines'
+include_recipe 'chef_portal::_refresh_iam_creds'
+include_recipe 'chef_classroom::_setup_portal_key'
+include_recipe 'chef_classroom::_setup_security_groups'
 
 machine_batch do
   1.upto(count) do |i|

--- a/recipes/deploy_workstations.rb
+++ b/recipes/deploy_workstations.rb
@@ -31,6 +31,8 @@ with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
 include_recipe 'chef_portal::_refresh_iam_creds'
+include_recipe 'chef_portal::_setup_security_groups'
+include_recipe 'chef_portal::_setup_portal_key'
 
 # we will need this data_bag later
 chef_data_bag 'class_machines'

--- a/recipes/deploy_workstations.rb
+++ b/recipes/deploy_workstations.rb
@@ -38,7 +38,7 @@ chef_data_bag 'class_machines'
 machine_batch do
   1.upto(count) do |i|
     machine "#{name}-workstation-#{i}" do
-      machine_options create_machine_options(region, 'amzn', workstation_size, ssh_key, 'nodes')
+      machine_options create_machine_options(region, 'amzn', workstation_size, portal_key, 'nodes')
       tag 'workstation'
       recipe 'chef_workstation::full_stack'
       attribute 'guacamole_user', 'chef'

--- a/recipes/destroy_all.rb
+++ b/recipes/destroy_all.rb
@@ -26,8 +26,10 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+include_recipe 'chef_portal::_refresh_iam_creds'
 include_recipe 'chef_classroom::destroy_workstations'
 include_recipe 'chef_classroom::destroy_nodes'
 include_recipe 'chef_classroom::destroy_server'
-include_recipe 'chef_classroom::destroy_portal'
-include_recipe 'chef_classroom::_destroy_security_groups'
+# include_recipe 'chef_classroom::destroy_portal'
+# include_recipe 'chef_classroom::_destroy_security_groups'
+include_recipe 'chef_classroom::_destroy_portal_key'

--- a/recipes/destroy_nodes.rb
+++ b/recipes/destroy_nodes.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 machine_batch do
   action :destroy
   machines 1.upto(count).map { |i| "#{name}-node1-#{i}" }

--- a/recipes/destroy_portal.rb
+++ b/recipes/destroy_portal.rb
@@ -33,3 +33,9 @@ name = node['chef_classroom']['class_name']
 machine "#{name}-portal" do
   action :destroy
 end
+
+aws_security_group "training-#{name}-portal" do
+  action :destroy
+end
+
+include_recipe 'chef_classroom::_destroy_workstation_key'

--- a/recipes/destroy_server.rb
+++ b/recipes/destroy_server.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 machine "#{name}-chefserver" do
   action :destroy
 end

--- a/recipes/destroy_workstations.rb
+++ b/recipes/destroy_workstations.rb
@@ -30,6 +30,8 @@ require 'chef/provisioning/aws_driver'
 with_driver "aws::#{region}"
 name = node['chef_classroom']['class_name']
 
+include_recipe 'chef_portal::_refresh_iam_creds'
+
 machine_batch do
   action :destroy
   machines 1.upto(count).map { |i| "#{name}-workstation-#{i}" }


### PR DESCRIPTION
This PR resolves #15, makes #37 moot, and sets up #14 for implementation.  The PR still lacks a README.  But the code here makes the workflow go like so:
1. Clone the chef_classroom repo
2. Setup your AWS config creds
3. Specify the IAM ARN name to associate with the portal via attributes
4. Run the `provision_portal` recipe

Note: the steps above can be taken care of if we packaged up a portal AMI and gave users instructions to start it with an IAM role that has `Ec2FullAccess`.

Once those steps are complete, the idea is that the WebUI would have buttons that invoke local commands.  Those buttons do nothing right now.  The classroom workflow steps are accomplished by ssh'ing to the node and running them manually (for now).
1. `chef-client -z -r 'recipe[chef_classroom::deploy_workstations]'`
2. `chef-client -z -r 'recipe[chef_classroom::destroy_workstations]'`
3. `chef-client -z -r 'recipe[chef_classroom::deploy_server]'`
4. `chef-client -z -r 'recipe[chef_classroom::deploy_first_nodes]'`
5. `chef-client -z -r 'recipe[chef_classroom::deploy_multi_nodes]'`

This has been tested in us-east-1, but presumably the multi-region localizations still work.
