### PR TITLE
Temporary workaround for chef-provisioning-aws issue #154

### DIFF
--- a/recipes/_setup_security_groups.rb
+++ b/recipes/_setup_security_groups.rb
@@ -32,6 +32,7 @@ name = node['chef_classroom']['class_name']
 
 aws_security_group "training-#{name}-workstations" do
   action :create
+  ignore_failure true
   inbound_rules class_source_addr         => [22],
                 node['ec2']['local_ipv4'] => [22]   if type == 'linux'
   inbound_rules class_source_addr         => [3389],
@@ -40,6 +41,7 @@ end
 
 aws_security_group "training-#{name}-nodes" do
   action :create
+  ignore_failure true
   inbound_rules "training-#{name}-workstations" => [22, 5985, 5986],
                 node['ec2']['local_ipv4']       => [22, 3389, 5985, 5986],
                 class_source_addr               => [22, 3389, 5985, 5986]
@@ -47,6 +49,7 @@ end
 
 aws_security_group "training-#{name}-chef_server" do
   action :create
+  ignore_failure true
   inbound_rules class_source_addr         => [80, 443],
                 "training-#{name}-nodes"  => [443],
                 node['ec2']['local_ipv4'] => [22]

--- a/recipes/deploy_portal.rb
+++ b/recipes/deploy_portal.rb
@@ -37,11 +37,12 @@ include_recipe 'chef_classroom::_setup_workstation_key'
 
 aws_security_group "training-#{name}-portal" do
   action :create
+  ignore_failure true
   inbound_rules class_source_addr => [22, 80, 8080]
 end
 
-machine "#{name}-portal" do
-  machine_options create_machine_options(region, 'centos', portal_size, workstation_key, 'portal')
-  recipe 'chef_portal::fundamentals_3x'
-  converge true
-end
+#machine "#{name}-portal" do
+#  machine_options create_machine_options(region, 'centos', portal_size, workstation_key, 'portal')
+#  recipe 'chef_portal::fundamentals_3x'
+#  converge true
+#end


### PR DESCRIPTION
The `aws_security_group` resource appears to be mangling port ranges when comparing desired state to existing state.  As such, it bombs out when applied to an already existing SG.

This workaround is less than ideal.  However, these resources have proved reliable in setting up.  They only become an issue when recipes `deploy_workstations` or `deploy_portal` hit an error.  The recommended 'fix' for transient error conditions (yay AWS) is to re-run the recipe.  Currently, these two recipes can't run cleanly because we hit issue 154.  That bug is currently triaged and in the queue for fixing.  So the lesser of two evils in the meantime seems to be setting `ignore_failure` on these resources until that behavior is fixed.
