### PR TITLE
Portal Site Support

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,5 @@ source 'https://supermarket.chef.io'
 
 metadata
 cookbook 'chef_workstation', git: 'git://github.com/gmiranda23/chef_workstation.git'
-# cookbook 'guacamole', git: 'git://github.com/mattstratton/guacamole-cookbook.git'
 cookbook 'guacamole', git: 'git://github.com/gmiranda23/guacamole-cookbook.git'
-cookbook 'chef_portal', git: 'git://github.com/gmiranda23/chef_portal.git'
+cookbook 'chef_portal', git: 'git://github.com/burtlo/chef_portal.git'

--- a/Berksfile
+++ b/Berksfile
@@ -3,4 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 cookbook 'chef_workstation', git: 'git://github.com/gmiranda23/chef_workstation.git'
 cookbook 'guacamole', git: 'git://github.com/gmiranda23/guacamole-cookbook.git'
-cookbook 'chef_portal', git: 'git://github.com/burtlo/chef_portal.git'
+cookbook 'chef_portal', git: 'git://github.com/gmiranda23/chef_portal.git'

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This cookbook manages the deployment logic for managing instances used in Chef t
 In order to use this repo, you must have the following setup:
 
 #### Chef Requirements
-* Install ChefDK 0.6.2
+* Install ChefDK 0.9.0
 * Update chef-provisioning to 1.2.1
-* Update chef-provisioning-aws to 1.3.0
+* Update chef-provisioning-aws to 1.5.1
 
 #### AWS Requirements
 * [AWS API credentials][APIcreds] to start a classroom portal EC2 instance
@@ -56,7 +56,7 @@ Additional actions [from the web UI][WebUIactions] are not yet available.  So to
     [root@PORTAL_ADDRESS]# cd chef_classroom
     ```
 
-2. Presently, you have to set your classroom attributes once again on the portal instance.  **Ensure you set the same ARN name as you used to provision the portal instance.  Again, set all of your desired classroom settings here.** 
+2. Presently, you have to set your classroom attributes once again on the portal instance.  **Ensure you set the same ARN name as you used to provision the portal instance.  Again, set all of your desired classroom settings here.**
 Every time you make a local modification to the code in the `chef_classroom` cookbook dir, you must re-vendor cookbooks.  (TODO: fix this duplicate step)
 
      ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -219,7 +219,8 @@ module ChefHelpers # Helper Module for general purposes
       options[:is_windows] = true
     end
     if group == 'portal'
-      options[:bootstrap_options][:iam_instance_profile] = node['chef_classroom']['iam_instance_profile']
+      # options[:bootstrap_options][:iam_instance_profile] = node['chef_classroom']['iam_instance_profile']
+      options[:bootstrap_options][:iam_instance_profile] = { :arn => node['chef_classroom']['iam_instance_profile'] }
     end
     unless group == 'portal'
       options[:use_private_ip_for_ssh] = true

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -219,7 +219,6 @@ module ChefHelpers # Helper Module for general purposes
       options[:is_windows] = true
     end
     if group == 'portal'
-      # options[:bootstrap_options][:iam_instance_profile] = node['chef_classroom']['iam_instance_profile']
       options[:bootstrap_options][:iam_instance_profile] = { :arn => node['chef_classroom']['iam_instance_profile'] }
     end
     unless group == 'portal'

--- a/recipes/deploy_portal.rb
+++ b/recipes/deploy_portal.rb
@@ -46,3 +46,15 @@ machine "#{name}-portal" do
   recipe 'chef_portal::fundamentals_3x'
   converge true
 end
+
+# TODO: There seems like there is a workstation key
+# TODO: There also seems to be some reason that we have workstation key and portal key
+#        and I think that I am the problem in naming that issue
+key_name = "#{name}-workstation_key"
+
+# Get the newly generated key that we created to the portal machine
+machine_file "/root/.ssh/#{name}-portal_key" do
+  machine "#{name}-portal"
+  local_path "#{ENV['HOME']}/.ssh/#{key_name}"
+  action :upload
+end


### PR DESCRIPTION
Fix for ChefDK 0.8.1 and greater with chef-provisioning-aws 1.5.1 to correctly accept the role for the class (arn).

Copy the key generated locally to the remote machine
